### PR TITLE
Changed docker-compose version to '3.3' and added 'localhost'

### DIFF
--- a/back/reimbursinator/settings.py
+++ b/back/reimbursinator/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'w*d2$rg#i88&6^9u2)jl0!4_)=_e1)0fxreofqzb(qxaw$3+$d'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['192.168.99.100']
+ALLOWED_HOSTS = ['localhost','192.168.99.100']
 
 
 # Application definition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.3'
 
 services:
   api:


### PR DESCRIPTION
In order for our docker config to work on all our computers, I changed the docker-compose version to 3.3, which seems to work for both Preston and I. I also added "localhost" to the list of hosts in the django settings file, so those of you running the linux or full pc/mac versions of docker can access the django API by visiting https://localhost:8444.

Oh, and this is also a test pull request to see if I can make and merge a branch correctly. :D