### PR TITLE
Changed docker-compose.yml version to 2.0 and tried to fix recursion …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '3.3'
+version: '2.0'
 
 services:
   api:
     build: ./back
+    image: reimbursinator_back
     command: gunicorn --bind 0.0.0.0:444 --keyfile /etc/ssl/private/selfsigned.key --certfile /etc/ssl/private/selfsigned.crt reimbursinator.wsgi:application 
     #volumes:
     #  - ./app/:/usr/src/back/
@@ -12,6 +13,7 @@ services:
       - SECRET_KEY=please_change
   web:
     build: ./front
+    image: reimbursinator_front
     image: nginx:1.10.3
     ports:
       - "8443:443"


### PR DESCRIPTION
This merge changes the docker-compose.yml version to 2.0, which seems to be the one that works on all our dev machines. Run `docker-compose up -d --build` to test.

I've also attempted to apply the fix for the recursion bug Preston ran into. I think the name for the front being "nginx" and a dependency inside it also being "nginx" was causing problems. It seems that giving the images their own names fixes this, so now the backend image will be named `reimbursinator_back` and the front will be `reimbursinator_front`. Preston, you may be able to test this for me and see if it fixes the issue.