### PR TITLE
Fix login logout favicon bugs

### DIFF
--- a/front/static/dashboard.html
+++ b/front/static/dashboard.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="shortcut icon" href="img/favicon.ico">
     <title>Reimbursinator</title>
 </head>
 <body>

--- a/front/static/index.html
+++ b/front/static/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="shortcut icon" href="img/favicon.ico">
     <title>Reimbursinator</title>
 </head>
 <body>

--- a/front/static/js/logout.js
+++ b/front/static/js/logout.js
@@ -29,6 +29,5 @@ function postToLogoutEndpoint(event) {
     xhr.send();
 }
 
-const logoutLinks = document.querySelectorAll(".log-out-link");
-logoutLinks[0].addEventListener("click", postToLogoutEndpoint);
-logoutLinks[1].addEventListener("click", postToLogoutEndpoint);
+const logoutLink = document.querySelector(".log-out-link");
+logoutLink.addEventListener("click", postToLogoutEndpoint);

--- a/front/static/login.html
+++ b/front/static/login.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="shortcut icon" href="img/favicon.ico">
     <title>Log in</title>
 </head>
 <body>
@@ -42,6 +42,6 @@
         </div>
     </div>
     <p id="errorReport"><p>
-    <script src="login.js"></script>
+    <script src="js/login.js"></script>
 </body>
 </html>

--- a/front/static/signup.html
+++ b/front/static/signup.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="shortcut icon" href="img/favicon.ico">
     <title>Sign up</title>
 </head>
 <body style="background-color: lightgreen">


### PR DESCRIPTION
This update will fix the missing favicon bug on all the pages and restore the ability to log in and out. To test:

1. Open the dev tools console (ctrl+shift+i). Make sure to set the console logging to persist. In Firefox check "Persist Logs" on the right hand side of the console. In Chrome select the settings gear icon on the right hand of the console and check "Preserve log".
2. Starting at the index, confirm that the R favicon displays on the tab of each page (index.html, signup.html, login.html, dashboard.html). You may have to refresh the page if your browser has cached it.
3. Log in at login.html and confirm you get a success message in the console.
4. Log out from the dashboard and confirm you get a log out success message and you are returned to index.html.