### PR TITLE
Removed duplicate 'image:' line in docker-compose, trying to fix bug.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
   web:
     build: ./front
     image: reimbursinator_front
-    image: nginx:1.10.3
     ports:
       - "8443:443"
     environment:


### PR DESCRIPTION
I must have botched the last attempt to fix the docker file. There was a duplicate "image:" line. Should work now.

Just start the server and load an api page to check things still work.