### PR TITLE
Enabled cors headers for django

### DIFF
--- a/back/Pipfile
+++ b/back/Pipfile
@@ -7,6 +7,8 @@ verify_ssl = true
 
 [packages]
 django = "==2.1.5"
+django-cors-headers = "==2.4.0"
+
 gunicorn = "==19.6.0"
 
 [requires]

--- a/back/Pipfile.lock
+++ b/back/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a46ef04ffac2e51c6fd60967adce8d1967758dcdfee3fb9804c0b929110c2a92"
+            "sha256": "5f6bc22a581526fd5e7cba376397b8d499b15a0c071bdcc5cc799c32859f88ed"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,19 @@
     "default": {
         "django": {
             "hashes": [
-                "sha256:068d51054083d06ceb32ce02b7203f1854256047a0d58682677dd4f81bceabd7",
-                "sha256:55409a056b27e6d1246f19ede41c6c610e4cab549c005b62cbeefabc6433356b"
+                "sha256:a32c22af23634e1d11425574dce756098e015a165be02e4690179889b207c7a8",
+                "sha256:d6393918da830530a9516bbbcbf7f1214c3d733738779f06b0f649f49cc698c3"
             ],
             "index": "pypi",
-            "version": "==2.1.4"
+            "version": "==2.1.5"
+        },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:5545009c9b233ea7e70da7dbab7cb1c12afa01279895086f98ec243d7eab46fa",
+                "sha256:c4c2ee97139d18541a1be7d96fe337d1694623816d83f53cb7c00da9b94acae1"
+            ],
+            "index": "pypi",
+            "version": "==2.4.0"
         },
         "gunicorn": {
             "hashes": [

--- a/back/reimbursinator/settings.py
+++ b/back/reimbursinator/settings.py
@@ -39,9 +39,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'backend',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -50,6 +52,12 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CORS_ORIGIN_WHITELIST = (
+    'localhost:8443',
+    '192.168.99.100:8443',
+    '127.0.0.1:8443',
+)
 
 ROOT_URLCONF = 'reimbursinator.urls'
 


### PR DESCRIPTION
This allows our backend to accept requests from other hosts. To test:

1. Start docker and load the front/back as usual.
2. Go to `https://localhost:8443` (frontend)
3. Open dev console
4. Paste and run the following:

```
let f = function() { console.log(this.responseText) };
let r = new XMLHttpRequest();
r.addEventListener("load", f);
r.open("GET", "https://localhost:8444/create_report/");
r.send();
```

You should see a bunch of json if things are working.