### PR TITLE
Add list report history functionality to view_history.html

### DIFF
--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -86,7 +86,7 @@ function getReportHistory(event) {
     console.log(`Attempting a connection to the following endpoint: ${url}`);
 
     xhr.open("GET", url, true);
-    xhr.setRequestHeader("Authorization", `Token  ${token}`);
+    //xhr.setRequestHeader("Authorization", `Token  ${token}`);
     xhr.onreadystatechange = function() {
         if (this.readyState === 4) {
             if (this.status === 200) {

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -1,0 +1,83 @@
+function displayListOfReports(listOfReports) {
+    const cardBody = document.querySelector(".card-body");
+    const table = document.createElement("table");
+    const reports = listOfReports.reports;
+    let rowsInserted = 0;
+
+    for (let i = 0; i < reports.length; i++) {
+            let title = reports[i].title;
+            let dateCreated = new Date(reports[i].date_created).toLocaleDateString("en-US");
+            let state = reports[i].state;
+            let dateSubmitted = (state === "created") ? "TBD": new Date(reports[i].date_submitted).toLocaleDateString("en-US");
+            let bodyRow = table.insertRow(i); 
+            
+            bodyRow.insertCell(0).innerHTML = title;
+            bodyRow.insertCell(1).innerHTML = dateCreated; 
+            bodyRow.insertCell(2).innerHTML = state;
+            bodyRow.insertCell(3).innerHTML = dateSubmitted;
+            rowsInserted++;
+    }
+
+    if (rowsInserted === 0) {
+        // Empty report list
+        const p = document.createElement("p");
+        p.innerHTML = "No reports found.";
+        cardBody.appendChild(p);
+    } else {
+        // Create table header, add to table, and append result to the card body
+        const thead = document.createElement("thead");
+        const tr = document.createElement("tr");
+
+        const headTitle = document.createElement("th");
+        headTitle.innerHTML = "Title";
+        tr.appendChild(headTitle);
+
+        const headDateCreated = document.createElement("th");
+        headDateCreated.innerHTML = "Date Created";
+        tr.appendChild(headDateCreated);
+
+        const headState = document.createElement("th");
+        headState.innerHTML = "State";
+        tr.appendChild(headState);
+
+        const headDateSubmitted = document.createElement("th")
+        headDateSubmitted.innerHTML = "Date Submitted";
+        tr.appendChild(headDateSubmitted);
+
+        thead.appendChild(tr);
+        table.prepend(thead);
+        table.classList.add("table", "table-striped", "table-responsive-sm");
+        cardBody.appendChild(table);
+    }
+}
+
+function getReportHistory(event) {
+    const token = localStorage.getItem("token");
+    const url = "https://localhost:8444/backend/list_report"
+    const xhr = new XMLHttpRequest();
+
+    xhr.open("GET", url, true);
+    xhr.setRequestHeader("Authorization", `Token  ${token}`);
+    xhr.onreadystatechange = function() {
+        if (this.readyState === 4) {
+            if (this.status === 200) {
+                console.log("GET list_report SUCCESS!");
+                console.log(`Server response:\n${this.response}`);
+                listOfReports = JSON.parse(this.response);
+                displayListOfReports(listOfReports);
+            } else {
+                console.log("GET list_report FAILURE!");
+                console.log(`Server status: ${this.status}`);
+                console.log(`Server response:\n${this.response}`);
+            }
+        }
+    };
+
+    xhr.onerror = function() {
+        alert("Connection error!");
+    };
+
+    xhr.send();
+}
+
+document.addEventListener("DOMContentLoaded", getReportHistory);

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -1,3 +1,30 @@
+// Hack to change endpoint url for each OS
+function getEndpointDomain() {
+    let OSName;
+    let domain;
+
+    if (navigator.appVersion.indexOf("Win") !== -1)
+        OSName = "Windows";
+    else if (navigator.appVersion.indexOf("Mac") !== -1)
+        OSName = "MacOS";
+    else if (navigator.appVersion.indexOf("X11") !== -1)
+        OSName = "UNIX";
+    else if (navigator.appVersion.indexOf("Linux") !== -1)
+        OSName = "Linux";
+    else
+        OSName = "Unknown OS";
+
+    console.log(`Detected operating system: ${OSName}`);
+
+    if (OSName === "Windows") {
+        domain = "https://192.168.99.100:8444/";
+    } else {
+        domain = "https://localhost:8444/"
+    }
+
+    return domain;
+}
+
 function displayListOfReports(listOfReports) {
     const cardBody = document.querySelector(".card-body");
     const table = document.createElement("table");
@@ -53,8 +80,10 @@ function displayListOfReports(listOfReports) {
 
 function getReportHistory(event) {
     const token = localStorage.getItem("token");
-    const url = "https://localhost:8444/backend/list_report"
+    const url = getEndpointDomain() + "backend/list_report";
     const xhr = new XMLHttpRequest();
+
+    console.log(`Attempting a connection to the following endpoint: ${url}`);
 
     xhr.open("GET", url, true);
     xhr.setRequestHeader("Authorization", `Token  ${token}`);

--- a/front/static/view_history.html
+++ b/front/static/view_history.html
@@ -38,10 +38,20 @@
             </ul>
         </div>
     </nav>
-    <div class="container">
-        <p>View report history</p>
+    <div class="container pt-5">
+        <div class="row">
+            <div class="col-sm-8 mx-auto">
+                <div class="card bg-light text-dark">
+                    <div class="card-header text-center">
+                        <h3>Your Report History</h3>
+                    </div>
+                    <div class="card-body">
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <script src="js/logout.js"></script>
+    <script src="js/viewHistory.js"></script>
 </body>
 </html>
-


### PR DESCRIPTION
This update to view_history.html will populate a responsive table with data from the list_report endpoint. To test, navigate to view_history.html and confirm the table is centered and looks okay at full and mobile screen sizes. Since the table is responsive a scroll bar will appear at very small window sizes and the table may be pushed off screen if necessary. 