### PR TITLE
Reordered apps and middleware in settings.py, fixing CORS issue

### DIFF
--- a/back/reimbursinator/settings.py
+++ b/back/reimbursinator/settings.py
@@ -38,10 +38,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'backend',
+# 3rd party
     'rest_framework',
-    'users',
     'corsheaders',
+# local
+    'users',
+    'backend',
 ]
 
 REST_FRAMEWORK = {
@@ -52,6 +54,7 @@ REST_FRAMEWORK = {
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
I believe this fixes the CORS header issue in Firefox under Linux. Apps in the Django settings.py file weren't being loaded in the correct order. The order should be Django apps > 3rd parth apps > local apps. I don't know who can test this, but if you ever had an error trying to load the report edit/history screen, this should fix that issue.