### PR TITLE
Delete report action

### DIFF
--- a/front/static/edit_report.html
+++ b/front/static/edit_report.html
@@ -66,7 +66,7 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="editReportModalLabel"></h5>
+                    <h5 class="modal-title text-center" id="editReportModalLabel"></h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>

--- a/front/static/edit_report.html
+++ b/front/static/edit_report.html
@@ -66,8 +66,8 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title text-center" id="editReportModalLabel"></h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <h5 class="modal-title" id="editReportModalLabel"></h5>
+                    <button type="button" class="close float-right" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>

--- a/front/static/edit_report.html
+++ b/front/static/edit_report.html
@@ -74,7 +74,7 @@
                 <div class="modal-body">
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-danger">Delete Report</button>
+                    <button type="button" class="btn btn-danger delete-report">Delete Report</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                     <button type="button" class="btn btn-primary">Submit Report</button>
                 </div>

--- a/front/static/edit_report.html
+++ b/front/static/edit_report.html
@@ -67,7 +67,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="editReportModalLabel"></h5>
-                    <button type="button" class="close float-right" data-dismiss="modal" aria-label="Close">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -3,6 +3,37 @@ function getEndpointDomain() {
     return "https://" + window.location.hostname + ":8444/";
 }
 
+function removeDataFromEndpoint(url) {
+    const token = localStorage.getItem("token");
+    const xhr = new XMLHttpRequest();
+
+    console.log("Attempting a connection to the following endpoint: " + url);
+
+
+    xhr.open("DELETE", url, true);
+    xhr.setRequestHeader("Authorization", "Bearer " + token);
+    xhr.onreadystatechange = function() {
+        if (this.readyState === 4) {
+            if (this.status === 200) {
+                console.log("DELETE SUCCESS!");
+                console.log("Server response:\n" + this.response);
+                alert("Report deleted");
+                location.reload(true);
+            } else {
+                console.error("DELETE FAILURE!");
+                console.error("Server status: " + this.status);
+                console.error("Server response:\n" + this.response);
+            }
+        }
+    };
+
+    xhr.onerror = function() {
+        alert("Connection error!");
+    };
+
+    xhr.send();
+}
+
 // Make a GET request to url and pass response to callback function
 function getDataFromEndpoint(url, callback) {
     const token = localStorage.getItem("token");
@@ -334,6 +365,10 @@ document.addEventListener("click", function(event) {
     if (event.target && event.target.classList.contains("edit-report-button")) {
         console.log("Edit button clicked");
         const url = getEndpointDomain() + "api/v1/report/" + event.target.dataset.rid;
+        const deleteButton = document.querySelector(".delete-report");
+        if (deleteButton) {
+            deleteButton.setAttribute("data-rid", event.target.dataset.rid);
+        }
         getDataFromEndpoint(url, createEditReportForm);
     }
     if(event.target && event.target.classList.contains("view-report-button"))
@@ -343,4 +378,14 @@ document.addEventListener("click", function(event) {
         getDataFromEndpoint(url, displayReport);
     }
     // TODO: Add View Report
+
+    if(event.target && event.target.classList.contains("delete-report")) {
+        event.preventDefault();
+        console.log("Delete report button clicked");
+        const result = confirm("Are you sure you want to delete this report?");
+        if (result) {
+            const url = getEndpointDomain() + "api/v1/report/" + event.target.dataset.rid;
+            removeDataFromEndpoint(url);
+        }
+    }
 });

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -50,7 +50,7 @@ function createFormGroup(field) {
     label.classList.add("col-sm-4", "col-form");
     label.innerHTML = field.label + ": ";
     label.setAttribute("for", field.field_name);
-    
+
     const div = document.createElement("div");
     div.classList.add("col-sm-6");
 
@@ -172,10 +172,10 @@ function createCollapsibleCardBody(key, form, type, sectionDescription, sectionC
 
     // Create card body. Append form to body, body to wrapper div
     cardBody.appendChild(sectionAlert);
-    cardBody.insertAdjacentHTML("beforeend", sectionDescription); 
+    cardBody.insertAdjacentHTML("beforeend", sectionDescription);
     cardBody.appendChild(form);
     div.appendChild(cardBody);
-    
+
     return div;
 }
 
@@ -186,12 +186,14 @@ function createReportForm(parsedData, type) {
     accordion.classList.add("accordion");
 
     if (type === reportType.EDIT) {
-        console.log("reportType.EDIT");
         modalBody = document.querySelector("#editReportModalBody");
         modalLabel = document.querySelector("#editReportModalLabel");
         accordion.id = "editReportAccordion";
+        const deleteButton = document.querySelector(".delete-report");
+        if (deleteButton) {
+            deleteButton.setAttribute("data-rid", parsedData.report_pk);
+        }
     } else if (type === reportType.NEW) {
-        console.log("reportType.NEW");
         modalBody = document.querySelector("#newReportModalBody");
         modalLabel = document.querySelector("#newReportModalLabel");
         accordion.id = "newReportAccordion";
@@ -223,10 +225,10 @@ function createReportForm(parsedData, type) {
         for (let key in fields) {
             let field = fields[key];
 
-            console.log("Field label: " + field.label); 
-            console.log("Field type: " + field.type); 
-            console.log("Field value: " + field.value); 
-            
+            console.log("Field label: " + field.label);
+            console.log("Field type: " + field.type);
+            console.log("Field value: " + field.value);
+
             // Create a form group for each field and add it to the form
             let formGroup = createFormGroup(field);
             form.appendChild(formGroup);
@@ -241,10 +243,10 @@ function createReportForm(parsedData, type) {
 
         // Create collapsible card body, append form to it, append card to accordion
         let cardBody = createCollapsibleCardBody(key, form, type, section.html_description, section.completed);
-        collapsibleCard.appendChild(cardBody); 
+        collapsibleCard.appendChild(cardBody);
         accordion.appendChild(collapsibleCard);
     }
-   
+
     modalBody.appendChild(accordion);
 }
 
@@ -268,9 +270,9 @@ function displayListOfReports(parsedData) {
             let dateSubmitted;
             let rid = reports[i].report_pk;
 
-            let bodyRow = tbody.insertRow(i); 
+            let bodyRow = tbody.insertRow(i);
             bodyRow.insertCell(0).innerHTML = title;
-            bodyRow.insertCell(1).innerHTML = dateCreated; 
+            bodyRow.insertCell(1).innerHTML = dateCreated;
 
             let stateCell = bodyRow.insertCell(2);
             stateCell.innerHTML = state;
@@ -377,10 +379,6 @@ document.addEventListener("click", function(event) {
         if (event.target.classList.contains("edit-report-button")) {
             const url = getEndpointDomain() + "api/v1/report/" + event.target.dataset.rid;
             const type = reportType.EDIT;
-            const deleteButton = document.querySelector(".delete-report");
-            if (deleteButton) {
-                deleteButton.setAttribute("data-rid", event.target.dataset.rid);
-            }
             makeAjaxRequest("GET", url, createReportForm, type);
         } else if (event.target.classList.contains("view-report-button")) {
             console.log("View button clicked");


### PR DESCRIPTION
This update enables deleting a report from the frontend. I also refactored the code responsible for the AJAX requests and reduced it to a single function that accepts an HTTP method, a url, a callback function, a report type, and a payload. The last two arguments are optional.

To test, log in and go to edit report. Select a report to edit. Go to the bottom of the modal popup and click the delete report button. A popup will prompt you for confirmation. Click OK and another popup should tell you that the report has been deleted. I just grabbed the response message the endpoint returns which includes the report_pk. Maybe we can change that to the title of the deleted report instead? After deletion the screen should reload and the deleted report should no longer appear in the report table.

Try creating a report and then editing and deleting it. Also confirm view report still works.