### PR TITLE
Add frontend save section functionality

### DIFF
--- a/back/backend/views.py
+++ b/back/backend/views.py
@@ -154,6 +154,8 @@ def report_detail(request, report_pk):
 # update a section with new data
 @api_view(['PUT'])
 def section(request, report_pk, section_pk):
+    
+    """ original stub
     data = {
         "message": "Updated report {0}, section {1}.".format(report_pk, section_pk),
         "fields": {
@@ -162,6 +164,12 @@ def section(request, report_pk, section_pk):
             "fare": "1024.99",
             "lowest_fare_screenshot": "image",
         }
+    }
+    """
+
+    data = {
+        "message": "Updated report {0}, section {1}.".format(report_pk, section_pk),
+        "request.data": request.data
     }
 
     return JsonResponse(data)


### PR DESCRIPTION
This update will send data to the section update endpoint using the HTTP PUT request method. I made some minor changes to the section method in views.py to return JSON showing the content of request.data. To test, log in, create report, open the web dev console, enter some data in a section's input fields and click save. You should see the html element of that section's form in the console with the attributes data-rid and data-sid. These correspond to the report_pk and section id, respectively. If the PUT is successful an alert popup should appear on the page with the contents of request.data and the report_pk and section id. Those should match the ones on the form. The keys and values of the request.data entry should match what you entered and the keys should match the name attribute of the form's inputs. Repeat the process with edit report.