### PR TITLE
Added 'number' attribute to fields in the policy file, so they actually sort

### DIFF
--- a/back/backend/policy.py
+++ b/back/backend/policy.py
@@ -79,7 +79,7 @@ pol.add_section(flight_section)
 lodging_section = Section(
     title="Hotel Info",
     html_description="<p>Enter hotel info here.\nPer diem rates can be found at "
-                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates'>this link</a></p>",
+                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target="_blank">this link</a></p>",
     fields={
         "check-in_date": {"number": 0, "label": "Check-in date", "field_type": "date"},
         "check-out_date": {"number": 1, "label": "Check-out date", "field_type": "date"},
@@ -126,7 +126,7 @@ pol.add_section(transport_section)
 per_diem_section = Section(
     title="Per Diem",
     html_description="<p>Enter info about meals and incidentals here.\nPer diem rates can be found at "
-                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates'>this link</a></p>",
+                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target="_blank">this link</a></p>",
     fields={
         "duration": {"number":0, "label": "How many days was your trip?", "field_type": "integer"},
         "rate": {"number":1, "label": "What is the per diem rate for your destination?", "field_type": "decimal"},

--- a/back/backend/policy.py
+++ b/back/backend/policy.py
@@ -39,7 +39,7 @@ general_section = Section(
     title="General Info",
     html_description="",
     fields={
-        "destination": {"label": "Destination City", "field_type": "string"},
+        "destination": {"number": 0, "label": "Destination City", "field_type": "string"},
     }
 )
 
@@ -57,12 +57,12 @@ flight_section = Section(
     title="Flight Info",
     html_description="<p>Enter flight details here.</p>",
     fields={
-        "international": {"label": "Is this an international flight?", "field_type": "boolean"},
-        "departure_date": {"label": "Departure date", "field_type": "date"},
-        "return_date": {"label": "Return date", "field_type": "date"},
-        "fare": {"label": "Fare", "field_type": "decimal"},
-        "layovers": {"label": "Transit wait", "field_type": "integer"},
-        "fare_search_screenshot": {"label": "Screenshot of fare search", "field_type": "file"},
+        "international": {"number": 0, "label": "Is this an international flight?", "field_type": "boolean"},
+        "departure_date": {"number": 1, "label": "Departure date", "field_type": "date"},
+        "return_date": {"number": 2, "label": "Return date", "field_type": "date"},
+        "fare": {"number": 3, "label": "Fare", "field_type": "decimal"},
+        "layovers": {"number": 4, "label": "Transit wait", "field_type": "integer"},
+        "fare_search_screenshot": {"number": 5, "label": "Screenshot of fare search", "field_type": "file"},
     }
 )
 
@@ -81,10 +81,10 @@ lodging_section = Section(
     html_description="<p>Enter hotel info here.\nPer diem rates can be found at "
                      "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates'>this link</a></p>",
     fields={
-        "check-in_date": {"label": "Check-in date", "field_type": "date"},
-        "check-out_date": {"label": "Check-out date", "field_type": "date"},
-        "rate": {"label": "Per diem nightly rate", "field_type": "decimal"},
-        "cost": {"label": "Total Cost", "field_type": "decimal"}
+        "check-in_date": {"number": 0, "label": "Check-in date", "field_type": "date"},
+        "check-out_date": {"number": 1, "label": "Check-out date", "field_type": "date"},
+        "rate": {"number": 2, "label": "Per diem nightly rate", "field_type": "decimal"},
+        "cost": {"number": 3, "label": "Total Cost", "field_type": "decimal"}
     }
 )
 
@@ -108,8 +108,8 @@ transport_section = Section(
     title="Local Transportation",
     html_description="<p>How much did you spend on local transportation, in total?</p>",
     fields={
-        "duration": {"label": "How many days was your trip?", "field_type": "integer"},
-        "cost": {"label": "Total cost", "field_type": "decimal"}
+        "duration": {"number":0, "label": "How many days was your trip?", "field_type": "integer"},
+        "cost": {"number":1, "label": "Total cost", "field_type": "decimal"}
     }
 )
 
@@ -128,9 +128,9 @@ per_diem_section = Section(
     html_description="<p>Enter info about meals and incidentals here.\nPer diem rates can be found at "
                      "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates'>this link</a></p>",
     fields={
-        "duration": {"label": "How many days was your trip?", "field_type": "integer"},
-        "rate": {"label": "What is the per diem rate for your destination?", "field_type": "decimal"},
-        "cost": {"label": "Total Cost for meals and incidentals", "field_type": "decimal"}
+        "duration": {"number":0, "label": "How many days was your trip?", "field_type": "integer"},
+        "rate": {"number":1, "label": "What is the per diem rate for your destination?", "field_type": "decimal"},
+        "cost": {"number":2,"label": "Total Cost for meals and incidentals", "field_type": "decimal"}
     }
 )
 

--- a/back/backend/policy.py
+++ b/back/backend/policy.py
@@ -79,7 +79,7 @@ pol.add_section(flight_section)
 lodging_section = Section(
     title="Hotel Info",
     html_description="<p>Enter hotel info here.\nPer diem rates can be found at "
-                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target="_blank">this link</a></p>",
+                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target='_blank'>this link</a></p>",
     fields={
         "check-in_date": {"number": 0, "label": "Check-in date", "field_type": "date"},
         "check-out_date": {"number": 1, "label": "Check-out date", "field_type": "date"},
@@ -126,7 +126,7 @@ pol.add_section(transport_section)
 per_diem_section = Section(
     title="Per Diem",
     html_description="<p>Enter info about meals and incidentals here.\nPer diem rates can be found at "
-                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target="_blank">this link</a></p>",
+                     "<a href='https://www.gsa.gov/travel/plan-book/per-diem-rates' target='_blank'>this link</a></p>",
     fields={
         "duration": {"number":0, "label": "How many days was your trip?", "field_type": "integer"},
         "rate": {"number":1, "label": "What is the per diem rate for your destination?", "field_type": "decimal"},

--- a/back/backend/views.py
+++ b/back/backend/views.py
@@ -113,13 +113,11 @@ def report(request):
         s.save()
 
         # Create the fields
-        j = 0
         for key in section.fields:
             field = section.fields[key]
             f = Field.objects.create(section_id=s, field_name=key, label=field['label'],
-                                     number=j, field_type=field['field_type'], completed=False)
+                                     number=field['number'], field_type=field['field_type'], completed=False)
             f.save()
-            j = j+1
     
     # Return the newly created report
     data = get_reports(report.id)


### PR DESCRIPTION
Fields now display in the order they are numbered in the policy file. Unfortunately I had to do this because keys in python objects do not maintain order.

Start docker, then create a new report and the fields are actually in the same order as the policy file now. (^^;)

Also, I tweaked the links in the policy file so clicking on them now opens in a new tab, rather than the current tab. Create a new report then click on one of the two links to test.