### PR TITLE
create the submit functionality of submit report buttons

### DIFF
--- a/front/static/edit_report.html
+++ b/front/static/edit_report.html
@@ -83,7 +83,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-danger delete-report">Delete Report</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary">Submit Report</button>
+                    <button type="button" class="btn btn-primary" onclick="submitReport()">Submit Report</button>
                 </div>
             </div>
         </div>

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -469,3 +469,17 @@ document.addEventListener("submit", function(event) {
         makeAjaxRequest("PUT", url, alertCallback, null, formData);
     }
 });
+
+//listener to submit report button
+function submitReport() {
+        event.preventDefault();
+        console.log(event.target);
+        //May add title into confirm
+        const result = confirm("Are you sure you want to submit the report ?");
+        if (result) {
+          const url = getEndpointDomain() + "api/v1/report/rid";
+          makeAjaxRequest("PUT", url, function alertSubmitCallback(){
+            alert("Submitted!");
+          });
+        }
+}

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -472,12 +472,12 @@ document.addEventListener("submit", function(event) {
 
 //listener to submit report button
 function submitReport() {
-        event.preventDefault();
-        console.log(event.target);
+        //event.preventDefault();
+        //console.log(event.target);
         //May add title into confirm
         const result = confirm("Are you sure you want to submit the report ?");
         if (result) {
-          const url = getEndpointDomain() + "api/v1/report/rid";
+          const url = getEndpointDomain() + "api/v1/report/id";
           makeAjaxRequest("PUT", url, function alertSubmitCallback(){
             alert("Submitted!");
           });

--- a/front/static/new_report.html
+++ b/front/static/new_report.html
@@ -76,7 +76,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary">Submit Report</button>
+                    <button type="button" class="btn btn-primary" onclick="submitReport()">Submit Report</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Create the click listener for submit report buttons in new_report and edit report. JSON modification at the very end of viewHistory file. Add a listener on the clicking of the submit report button. After clicking the button, an alert comes out with confirm question to the user, then the PUT api calls back. To test it, choose the new report panel, create a new report and then click on the submit report button on the left-bottom side of the report. Similar instructions on edit report panel submit report button testing.