### PR TITLE
Removed extra keys

### DIFF
--- a/back/backend/views.py
+++ b/back/backend/views.py
@@ -1,10 +1,8 @@
-from rest_framework.decorators import api_view, parser_classes
+from rest_framework.decorators import api_view
 from django.http import JsonResponse
 from .models import *
 from .policy import pol
 import os
-from rest_framework.exceptions import ParseError
-from rest_framework.parsers import FileUploadParser, MultiPartParser
 
 def get_report(report_pk):
     """
@@ -81,13 +79,10 @@ def get_fields(s_id):
         # function that gets the corresponding datatype
         value = Field.get_datatype(i)
         data = {
-            "completed": i.completed,
             "field_name": i.field_name,
             "label": i.label,
             "field_type": i.field_type,
-            "number": i.number,
             "value": value,
-            "id": i.id,
         }
         # append the fields to array
         # use copy() to avoid overwriting


### PR DESCRIPTION
Removed extra keys from the JSON being sent to front end. 

Testing: Login, create/edit report, when enter and saving a section - the `fields` in JSON will not contain `number`, `id`, and `completed` values. 