### PR TITLE
Collapse scrolling

### DIFF
--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -1,6 +1,6 @@
 const reportType = {
     NEW : 1,
-    EDIT : 2,
+    EDIT : 2
 };
 
 // Hack to change endpoint url
@@ -152,14 +152,15 @@ function createFormGroup(sectionIdStr, field) {
             formGroup.appendChild(div);
             break;
         case "decimal":
-            input.type = "text";
+            input.type = "number";
             if (field.value === "0.00") {
                 input.value = "";
             } else {
                 input.value = field.value;
             }
             input.classList.add("form-control");
-            input.pattern = "\\d+(\\.\\d{2})?";
+            input.step = 0.01;
+            input.min = 0.00;
             formGroup.appendChild(label);
             div.appendChild(input)
             formGroup.appendChild(div);

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -1,7 +1,6 @@
 const reportType = {
     NEW : 1,
     EDIT : 2,
-    VIEW : 3
 };
 
 // Hack to change endpoint url
@@ -240,21 +239,14 @@ function createCollapsibleCardBody(form, type, sectionIdStr, sectionDescription,
     cardBody.classList.add("card-body");
     const sectionAlert = document.createElement("div");
 
-    if (sectionCompleted) {
-        if (ruleViolations.length === 0) {
-            collapseDiv.classList.add("collapse");
-        } else {
-            collapseDiv.classList.add("collapse", "show");
-        }
+    if (sectionCompleted && ruleViolations.length === 0) {
+        collapseDiv.classList.add("collapse");
+    } else if (sectionCompleted && ruleViolations.length > 0) {
+        collapseDiv.classList.add("collapse", "show");
     } else {
         sectionAlert.classList.add("alert", "alert-danger", "section-alert");
         sectionAlert.innerHTML = "This section is not complete";
-    }
-
-    if (type === reportType.EDIT) {
-        collapseDiv.setAttribute("data-parent", "#editReportAccordion");
-    } else {
-        collapseDiv.setAttribute("data-parent", "#newReportAccordion");
+        collapseDiv.classList.add("collapse", "show");
     }
 
     // Create card body. Append form to body, body to wrapper div


### PR DESCRIPTION
This update removes the data-parent attribute from the accordion's collapse div. This was preventing a user from closing sections and then reopening more than one closed section. Before only one closed section could be reopened at a single time.

I also made fields of decimal type render with input boxes of type number, the same input type as integer fields only with step values of 0.01 instead of whole numbers. This allows users to input decimal values such as 0.5 or 0.1. These numbers are still stored as 0.50 and 0.10 however.

Closes #95