### PR TITLE
Fixes three bugs relating to email and report formatting

### DIFF
--- a/back/.env
+++ b/back/.env
@@ -1,4 +1,0 @@
-EMAIL_HOST_USER=reimbursinator@gmail.com
-EMAIL_HOST_PASSWORD=Frank12345
-SUBMIT_REPORT_DESTINATION_EMAIL=kououken@gmail.com
-SUBMIT_REPORT_FROM_EMAIL=from-address@yourmail.com

--- a/back/.env
+++ b/back/.env
@@ -1,4 +1,4 @@
-EMAIL_HOST_USER=accountemail@yourmail.com
-EMAIL_HOST_PASSWORD=accountpasswordhere
-SUBMIT_REPORT_DESTINATION_EMAIL=to-address@yourmail.com
+EMAIL_HOST_USER=reimbursinator@gmail.com
+EMAIL_HOST_PASSWORD=Frank12345
+SUBMIT_REPORT_DESTINATION_EMAIL=kououken@gmail.com
 SUBMIT_REPORT_FROM_EMAIL=from-address@yourmail.com

--- a/back/backend/templates/backend/email.html
+++ b/back/backend/templates/backend/email.html
@@ -12,7 +12,11 @@
             {% for field in section.fields %}
                 <tr>
                     <td>{{field.label}}</td>
-                    <td>{{field.value|default:""}}</td>
+		    <td>{% if field.field_type == 'boolean' %}
+			    {{field.value|yesno:"yes,no"}}
+			{% else %}
+			    {{field.value|default:" "}}
+			{% endif %}</td>
                 </tr>
             {% endfor %}
             {% for rule in section.rule_violations %}

--- a/back/backend/templates/backend/email.txt
+++ b/back/backend/templates/backend/email.txt
@@ -8,7 +8,7 @@ Reference #: {{reference_number}}
 {% for section in sections %}
     {{section.title}}(SID: {{section.id}})
     {% for field in section.fields %}
-        {{field.label}}:  {{field.value|default:"empty"}}
+        {{field.label}}:  {% if field.field_type == 'boolean' %}{{field.value|yesno:"yes,no"}}{% else %}{{field.value|default:" "}}{% endif %}
     {% endfor %}
     {% for rule in section.rule_violations %}
         [RULE] {{rule.label}}:  {{rule.rule_break_text}}

--- a/back/backend/templates/backend/email.txt
+++ b/back/backend/templates/backend/email.txt
@@ -5,7 +5,7 @@
 
 Title: {{title}}
 Reference #: {{reference_number}}
-{% for section in sections %}
+{% for section in sections %}{% if section.completed %}
     {{section.title}}(SID: {{section.id}})
     {% for field in section.fields %}
         {{field.label}}:  {% if field.field_type == 'boolean' %}{{field.value|yesno:"yes,no"}}{% else %}{{field.value|default:" "}}{% endif %}
@@ -13,4 +13,4 @@ Reference #: {{reference_number}}
     {% for rule in section.rule_violations %}
         [RULE] {{rule.label}}:  {{rule.rule_break_text}}
     {% endfor %}
-{% endfor %}    
+{% endif %}{% endfor %}    

--- a/back/backend/views.py
+++ b/back/backend/views.py
@@ -414,7 +414,7 @@ def send_report_to_admin(request, report_pk, status):
     message = None
     if params['reference_number'] == '':
         message = EmailMultiAlternatives(
-            "[Reimbursinator {}] ({})".format(params['title'], status),
+            "[Reimbursinator] {} ({})".format(params['title'], status),
             msg_plain,
             from_email,
             [to_email],


### PR DESCRIPTION
This PR addresses 3 different bugs relating to report formatting:

1. boolean values appearing broken in emailed reports
2. all sections (whether complete or not) being sent in text emails
3. Subject line of reports created without ref # garbled

To test:

Set up `back/.env` with your email settings.

1. Log in as frank
2. Create a report with a ref #.
3. Enter at least one true and one false field and save those sections.
4. Submit the report for review.
5. Confirm that Subject line looks like "[Reimbursinator #123] Report Title (REVIEW)".
6. Confirm that question responses say "yes" and "no". Note: empty date fields will display "None"
7. View the original text email by clicking the dots in the upper right and selecting "Show original".
8. Confirm that question responses say "yes" and "no". Note: empty date fields will display "None"
9. Confirm that only sections you saved are shown in the text message.
10. Finally, create a report without a ref #, submit it for review, and confirm that the email subject line looks like "[Reimbursinator] Report Title (REVIEW)"

Closes #121
Closes #122
Closes #123