### PR TITLE
More tests, and simplified section update API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Edit at https://www.gitignore.io/?templates=linux,macos,python,django,windows,pycharm,intellij,visualstudio
 
 ### Django ###
+*.env
 *.log
 *.pot
 *.pyc
@@ -100,6 +101,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
+.env
 .venv
 env/
 venv/

--- a/back/backend/urls.py
+++ b/back/backend/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path('reports', views.reports),
     path('report/<int:report_pk>', views.report_detail),
     path('report/<int:report_pk>/final', views.finalize_report),
-    path('report/<int:report_pk>/section/<int:section_pk>', views.section),
+    path('section/<int:section_pk>', views.section),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/back/backend/views.py
+++ b/back/backend/views.py
@@ -270,7 +270,7 @@ def user_owns_section(user, section_id):
     return report_to_check.user_id == user
 
 @api_view(['PUT'])
-def section(request, report_pk, section_pk):
+def section(request, section_pk):
     """
     Updates the specified section with new data.
     

--- a/front/static/js/viewHistory.js
+++ b/front/static/js/viewHistory.js
@@ -606,7 +606,7 @@ document.addEventListener("submit", function(event) {
         let saveButton = event.target.lastElementChild;
         animateButton(saveButton, "  Saving...");
         const formData = new FormData(event.target);
-        const url = getEndpointDomain() + "api/v1/report/" + event.target.dataset.rid + "/section/" + event.target.dataset.sid;
+        const url = getEndpointDomain() + "api/v1/section/" + event.target.dataset.sid;
         makeAjaxRequest("PUT", url, updateSection, saveButton, formData);
     }
 });


### PR DESCRIPTION
I created tests for the `user_owns_section`, `user_owns_report`, `generate_named_fields_for_section` and `section_complete` functions. This branch also simplifies the section updating API endpoint. It has changed from `/api/v1/report/xx/section/xx` to `/api/v1/section/xx`, since the report number wasn't being used by the front or back end in this case.

To run tests:

1. Start `pipenv shell`
2. Run `python manage.py test`

To see the new API in action:

1. Start docker
2. Log in and create a report
3. Save a couple sections and confirm that you are able to save section changes.

Also, the `.env` is back in the `.gitignore` file. Sorry for all the mess. It looks like we have to continue editing it manually each time we check out a branch.

Closes #119